### PR TITLE
Fixed Devices with spaces in name & leverage jsontool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-Author: Red5d - https://github.com/Red5d
+Original Author: Red5d - https://github.com/Red5d
+This version: Sean Payne - https://github.com/zerodivide1
 
 
 This is a Bash interface to the PushBullet API (https://www.pushbullet.com/).
@@ -6,6 +7,10 @@ This is a Bash interface to the PushBullet API (https://www.pushbullet.com/).
 It can list your available devices and push different types of data to them.
 
 Set your PushBullet API key by creating the file $HOME/.config/pushbullet and adding the line API_KEY=<your key> to it.
+Alternatively, you can call Pushbullet in a single line by setting the variable $CONFIG in the same call to pushbullet. For eample:
+```
+CONFIG=/path/to/pushbulletconfig bash -c pushbullet...
+```
 
 Requirements
 ------------

--- a/pushbullet
+++ b/pushbullet
@@ -2,7 +2,8 @@
 
 # Bash interface to the PushBullet api.
 
-# Author: Red5d - https://github.com/Red5d
+# Original Author: Red5d - https://github.com/Red5d
+# Author: Sean Payne - https://github.com/zerodivide1
 
 if [[ -z "$CONFIG" ]]
 then


### PR DESCRIPTION
Altered the listing and pushing functions to leverage jsontool to parse returned JSON from the PushBullet API.

Current logic assumes that the returned JSON is "prettified", but this could potentially change. Using jsontool, this allows access to the JSON data without grep workarounds and prevents problems if PushBullet decided to "unpretty" their API.

These commits also help fix a problem with device names that have a space in them (e.g. "Galaxy Nexus", "Nexus 7").
