### PR TITLE
refactor code from #25 and introduce check for PB_API_KEY

### DIFF
--- a/pushbullet
+++ b/pushbullet
@@ -6,15 +6,17 @@
 
 
 if [ ! -n "$PB_CONFIG" ]; then
-        PB_CONFIG=~/.config/pushbullet
+	PB_CONFIG=~/.config/pushbullet
 fi
+source $PB_CONFIG > /dev/null 2>&1
 
 API_URL=https://api.pushbullet.com/v2
 EXECUTABLE="$(cd "$( dirname "$0" )" && pwd )"
 PROGDIR="${EXECUTABLE%/*}"
 
-if [ ! -n "$PB_API_KEY" ]; then
-	source $PB_CONFIG
+if [ -z "$PB_API_KEY" ]; then
+	echo "could not find api key"
+	exit 1
 fi
 
 printUsage() {
@@ -154,11 +156,7 @@ push)
 		else
 		  JsonData='{"type": "list", "device_iden": "'"$dev_id"'", "title":"'"$4"'", "items":'"$itemlist"'}'
 		fi
-<<<<<<< HEAD
-		curlres=$(curl -s $API_URL/pushes -u "$API_KEY": -X POST \
-=======
 		curlres=$(curl -s $API_URL/pushes -u "$PB_API_KEY": -X POST \
->>>>>>> upstream/master
 		  --header 'Content-Type: application/json' --data-binary "$JsonData")
 		checkCurlOutput "$curlres"
 	;;

--- a/pushbullet
+++ b/pushbullet
@@ -139,20 +139,19 @@ push)
 		checkCurlOutput "$curlres"
 	;;
 	list)
-		argnum=0
-		for i in "$@"; do
-			let argnum=$argnum+1
-			if [[ $argnum -ge 5 ]];then
-				itemlist=$itemlist" -d items=$i"
-			fi
-		done
+		# print all array items after $4, convert them to a JSON array
+		# URLencoded data requests do not work for lists at the moment 
+		itemlist=$(printf '%s\n' "${@:5}" \
+			| awk ' BEGIN { ORS = ""; print "["; } { print "/@"$0"/@"; } END { print "]"; }' \
+			| sed "s^\"^\\\\\"^g;s^\/\@\/\@^\", \"^g;s^\/\@^\"^g")
 		if [ "$2" = "all" ]; then
-			curlres=$(curl -s $API_URL/pushes -u "$API_KEY": -d type=list -d title="$4" $itemlist -X POST)
+		  JsonData='{"type": "list", "title": "'"$4"'", "items": '"$itemlist"'}'
 		else
-			curlres=$(curl -s $API_URL/pushes -u "$API_KEY": -d device_iden="$dev_id" -d type=list -d title="$4" $itemlist -X POST)
+		  JsonData='{"type": "list", "device_iden": "'"$dev_id"'", "title":"'"$4"'", "items":'"$itemlist"'}'
 		fi
+		curlres=$(curl -s $API_URL/pushes -u "$API_KEY": -X POST \
+		  --header 'Content-Type: application/json' --data-binary "$JsonData")
 		checkCurlOutput "$curlres"
-
 	;;
 
 	file)


### PR DESCRIPTION
#25 introduced a backward incompatible change (API_KEY was renamed) as the script was silently failing because of this I add a check if PB_API_KEY is defined (not empty).

I also refactored the changes from #25 a bit.