### PR TITLE
Fix file push

### DIFF
--- a/pushbullet
+++ b/pushbullet
@@ -11,8 +11,7 @@ fi
 source $PB_CONFIG > /dev/null 2>&1
 
 API_URL=https://api.pushbullet.com/v2
-EXECUTABLE="$(cd "$( dirname "$0" )" && pwd )"
-PROGDIR="${EXECUTABLE%/*}"
+PROGDIR="$(cd "$( dirname "$0" )" && pwd )"
 
 if [ -z "$PB_API_KEY" ]; then
 	echo "could not find api key"


### PR DESCRIPTION
Program directory was determined incorrectly, hence a path to JSON.sh was wrong.

I was getting lots of "JSON.sh not found" errors:
```
./pushbullet: line 176: /Users/artur/Stuff/JSON.sh: No such file or directory
./pushbullet: line 176: /Users/artur/Stuff/JSON.sh: No such file or directory
./pushbullet: line 176: /Users/artur/Stuff/JSON.sh: No such file or directory
./pushbullet: line 176: /Users/artur/Stuff/JSON.sh: No such file or directory
./pushbullet: line 176: /Users/artur/Stuff/JSON.sh: No such file or directory
./pushbullet: line 176: /Users/artur/Stuff/JSON.sh: No such file or directory
./pushbullet: line 176: /Users/artur/Stuff/JSON.sh: No such file or directory
curl: no URL specified!
curl: try 'curl --help' or 'curl --manual' for more information
./pushbullet: line 194: /Users/artur/Stuff/JSON.sh: No such file or directory
./pushbullet: line 194: /Users/artur/Stuff/JSON.sh: No such file or directory
./pushbullet: line 194: /Users/artur/Stuff/JSON.sh: No such file or directory
```

The change seems to fix it. Tested on Fedora-ish distro and OS X.

The `EXECUTABLE` variable I am deleting isn't used anywhere else in the file.


