### PR TITLE
push-exitcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Set your PushBullet API key by creating the file $HOME/.config/pushbullet and ad
 
 This is intended to be a pure Bash utility with no non-Bash dependencies.
 
-Pushbullet-bash also features a shell function similar to projects like pushblast(https://github.com/alebcay/pushblast), pushbullet-exit(https://github.com/rfilmyer/pushbullet-exit) and pace(https://github.com/esamson/pace) to send a message after a specific command has finished.
+Pushbullet-bash also features a shell function similar to projects like [pushblast](https://github.com/alebcay/pushblast), [pushbullet-exit](https://github.com/rfilmyer/pushbullet-exit) and [pace](https://github.com/esamson/pace) to send a message after a specific command has finished.

--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ It can list your available devices and push different types of data to them.
 Set your PushBullet API key by creating the file $HOME/.config/pushbullet and adding the line PB_API_KEY=<your key> to it.
 
 This is intended to be a pure Bash utility with no non-Bash dependencies.
+
+Pushbullet-bash also features a shell function similar to projects like pushblast(https://github.com/alebcay/pushblast), pushbullet-exit(https://github.com/rfilmyer/pushbullet-exit) and pace(https://github.com/esamson/pace) to send a message after a specific command has finished.

--- a/push-exitcode.sh
+++ b/push-exitcode.sh
@@ -27,4 +27,5 @@ pb() {
 	fi
 
 	pushbullet push all note "$PUSH_TITLE Command completed on $(hostname)" "Finished $* in $TIME. Return code was $EXITCODE."
+	return $EXITCODE
 }

--- a/push-exitcode.sh
+++ b/push-exitcode.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Partly inspired by pace (https://github.com/esamson/pace)
+
+# Send a message through pushbullet after a command has finished.
+# Can be called in two ways:
+# apt-get update; pb # will just report the exit status.
+# pb apt-get update # will send the command, time till exit and return code.
+
+pb() {
+	EXITCODE=$?
+
+	if [ ! -z $1 ]; then
+		# when called with arguments execute these
+		START_TIME=$SECONDS
+		eval $*
+		EXITCODE=$?
+		ELAPSED_TIME=$(($SECONDS - $START_TIME))
+		TIME="$(($ELAPSED_TIME / 60)) min $(($ELAPSED_TIME % 60)) sec"
+	else
+		TIME="duration unknown"
+	fi
+
+	if [ $EXITCODE -eq 0 ] ; then
+		PUSH_TITLE="SUCCESS!"
+	else
+		PUSH_TITLE="FAIL!"
+	fi
+
+	pushbullet push all note "$PUSH_TITLE Command completed on $(hostname)" "Finished $* in $TIME. Return code was $EXITCODE."
+}


### PR DESCRIPTION
add a shell function similar to projects like [pushblast](https://github.com/alebcay/pushblast), [pushbullet-exit](https://github.com/rfilmyer/pushbullet-exit) and [pace](https://github.com/esamson/pace) to send a message after a specific command has finished.

The function can be called in two ways:
```apt-get update; pb``` will just report the exit status.
```pb apt-get update``` will send the command, time till exit and return code.