### PR TITLE
restructure the start of pushbullet

### DIFF
--- a/pushbullet
+++ b/pushbullet
@@ -1,19 +1,24 @@
 #! /bin/bash
 
 # Bash interface to the PushBullet api.
-
 # Author: Red5d - https://github.com/Red5d
-
-
-if [ ! -n "$PB_CONFIG" ]; then
-	PB_CONFIG=~/.config/pushbullet
-fi
-source $PB_CONFIG > /dev/null 2>&1
 
 API_URL=https://api.pushbullet.com/v2
 PROGDIR="$(cd "$( dirname "$0" )" && pwd )"
 
-if [ -z "$PB_API_KEY" ]; then
+if [ ! $(which curl) ]; then
+	echo "pushbullet-bash requires curl to run. Please install curl"
+	exit 1
+fi
+
+# override default PB_CONFIG if different file or API key has been given
+if [[ ! -n "$PB_CONFIG" ]] && [[ ! -n "$PB_API_KEY" ]]; then
+	PB_CONFIG=~/.config/pushbullet
+fi
+source $PB_CONFIG > /dev/null 2>&1
+
+# don't give warning when script is called with setup option
+if [[ -z "$PB_API_KEY" ]] && [[ "$1" != "setup" ]]; then
 	echo -e "\e[0;33mWarning, your API key is not set.\nPlease create \"$PB_CONFIG\" with a line starting with PB_API_KEY= and your PushBullet key\e[00m"
 	exit 1
 fi


### PR DESCRIPTION
This pull requests:

- reorganises the checks at the top of pushbullet-bash to make it more readable
- fix check for PB_CONFIG so that PB_API_KEY will not be overwritten by pushbullet-bash if ~/.config/pushbullet is present
- add some comments

Line 21 already included an enhanced check for the next pull request I am going to open. I decided to include it here to avoid potential merge conflicts.

Regards