### PR TITLE
Allow pushbullet-bash to be setup with OAuth

### DIFF
--- a/pushbullet
+++ b/pushbullet
@@ -35,6 +35,7 @@ pushes active - List your 'active' pushes (pushes that haven't been deleted).
 delete \$iden - Delete a specific push.
 delete except \$number - Delete all pushes except the last \$number.
 delete all - Delete all pushes.
+setup - Use OAuth to retrieve a PushBullet API key for pushbullet-bash.
 
 Types: 
 note
@@ -240,7 +241,23 @@ push)
 	;;
 	esac
 ;;
+setup)
+	CLIENT_ID=u1DAx9KcrmMRUjhcMb3qWOZluwE2MjKa
+	REDIRECT_URI="https%3A%2F%2Ffbartels.github.io%2Fpushbullet-bash"
+	OAUTH_URL="https://www.pushbullet.com/authorize?client_id=$CLIENT_ID&redirect_uri=$REDIRECT_URI&response_type=token&scope=everything"
+	echo
+	echo "Please open the following URL manually if it did not open automatically:"
+	echo
+	echo "$OAUTH_URL"
+	echo
+	echo "Before continuing you need to save your newly created token in $PB_CONFIG"
 
+	if [ "$(uname)" == "Darwin" ]; then
+		open "$OAUTH_URL"
+	else
+		xdg-open "$OAUTH_URL" > /dev/null
+	fi
+;;
 *)
 	printUsage
 	;;

--- a/pushbullet
+++ b/pushbullet
@@ -255,7 +255,7 @@ setup)
 	if [ "$(uname)" == "Darwin" ]; then
 		open "$OAUTH_URL"
 	else
-		xdg-open "$OAUTH_URL" > /dev/null
+		xdg-open "$OAUTH_URL" &> /dev/null
 	fi
 ;;
 *)


### PR DESCRIPTION
This pull request add the ability to pushbullet-bash to register itself as a client instead of having to copy the API key from the pushbullet settings screen.

For testing I have included a redirect page inside of my fork (you would need to create an empty branch called gh-pages so that I can do a pull request for this page). The page is using a default template for github pages (with small modifications) and uses some nice javascript tricks I got from https://github.com/esamson/pace.

After merging you can create a CLIENT_ID of your own at https://www.pushbullet.com/create-client