### PR TITLE
prevent empty lines in device listing 

### DIFF
--- a/pushbullet
+++ b/pushbullet
@@ -85,7 +85,7 @@ case $1 in
 list)
 	echo "Available devices:"
 	echo "------------------"
-	curl -s "$API_URL/devices" -u "$PB_API_KEY": | tr ',' '\n' | grep nickname | sort -n | cut -d '"' -f4
+	curl -s "$API_URL/devices" -u "$PB_API_KEY": | tr ',' '\n' | grep \"nickname\" | sort -n | cut -d '"' -f4
 	echo "all"
 	echo
 	echo "Contacts:"


### PR DESCRIPTION
Today I've set up pushbullet-bash on a new system and while testing my access key I came across some empty lines in the output of ```pushbullet list```.

As it turns out this was because there (now?) seems to be a field called "generated_nickname", which is still matched by the current grep command.

This patch modifies the grep command so it also matches the quotes around nichname.