### PR TITLE
one more body on stdin fix

### DIFF
--- a/pushbullet
+++ b/pushbullet
@@ -153,7 +153,7 @@ push)
 	if [[ $5 == http://* ]] || [[ $5 == https://* ]]; then
 		url="$5"
 	else
-		body="$5"
+		body=${body:-$5}
 		url="$6"
 	fi
 


### PR DESCRIPTION
The last implementation would only work when giving the stdin body when sending a link. This way the stdin body will also be set when sending notes and files,