### PR TITLE
properly escape new lines to preserve them when pushing notes

### DIFF
--- a/pushbullet
+++ b/pushbullet
@@ -158,7 +158,7 @@ push)
 	fi
 
 	# replace newlines with an escape sequence
-	body="${body//$'\n'/\n}"
+	body="${body//$'\n'/\\n}"
 
 	case $3 in
 	note)


### PR DESCRIPTION
solution suggested in https://github.com/Red5d/pushbullet-bash/issues/54