### PR TITLE
Make the 'push link' arguments more robust

### DIFF
--- a/pushbullet
+++ b/pushbullet
@@ -44,8 +44,8 @@ file
 
 Type Parameters: 
 (all parameters must be put inside quotes if more than one word)
-\"note\" type: 	give the title and an optional message body.
-\"link\" type: 	give the title of the link, an optional message and the url.
+\"note\" type: 	give a title and an optional message body.
+\"link\" type: 	give an optional title of the link, an optional message, and the url.
 \"file\" type: 	give the path to the file and an optional message body.
 Hint:  The message body can also be given via stdin, leaving the message parameter empty.
 "
@@ -150,7 +150,11 @@ push)
 		body=$(echo "$body"|tr -dc '[:print:]\n')
 	fi
 
-	if [[ $5 == http://* ]] || [[ $5 == https://* ]]; then
+	if [[ $4 == http://* ]] || [[ $4 == https://* ]]; then
+		body=${body:-$5}
+		url="$4"
+	elif [[ $5 == http://* ]] || [[ $5 == https://* ]]; then
+		body=${body:-$6}
 		url="$5"
 	else
 		body=${body:-$5}

--- a/pushbullet
+++ b/pushbullet
@@ -44,7 +44,7 @@ file
 
 Type Parameters: 
 (all parameters must be put inside quotes if more than one word)
-\"note\" type: 	give a title and an optional message body.
+\"note\" type: 	give the title and an optional message body.
 \"link\" type: 	give an optional title of the link, an optional message, and the url.
 \"file\" type: 	give the path to the file and an optional message body.
 Hint:  The message body can also be given via stdin, leaving the message parameter empty.


### PR DESCRIPTION
I've modified the script slightly to fit a common use case I had where I didn't care about giving the link a title.

This change allows for the following arguments and handles missing ones gracefully. In the case where a title is omitted, the link URL is used as the title.

```
./pushbullet push all link http://link
./pushbullet push all link http://link <message>

./pushbullet push all link <title> http://link
./pushbullet push all link <title> http://link <message>

./pushbullet push all link <title> <message> http://link
```

If none of the arguments contains http:// or https://, the existing logic catches it and exits the script.

It could probably still be more robust but I figured others could benefit from this change.
