### PR TITLE
allow other curl options

### DIFF
--- a/pushbullet
+++ b/pushbullet
@@ -7,6 +7,8 @@ API_URL=https://api.pushbullet.com/v2
 PROGDIR="$(cd "$( dirname "$0" )" && pwd )"
 unset QUIET
 
+CURL="curl"
+
 info() {
 	if [[ -z ${QUIET} ]]; then
 		echo "$@"
@@ -137,14 +139,14 @@ checkPagination() {
 }
 
 getChats() {
-	curlres=$(curl --silent --header "Access-Token: $PB_API_KEY" \
+	curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
 	"$API_URL/chats")
 
 	# check if query needs pagination
 	chats=$curlres
 	cursor=$(checkPagination "$curlres")
 	until [ -z $cursor ]; do
-		curlres=$(curl --silent --header "Access-Token: $PB_API_KEY" \
+		curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
 		--data-urlencode cursor=$cursor \
 		--get \
 		"$API_URL/chats")
@@ -155,7 +157,7 @@ getChats() {
 }
 
 getDevices() {
-	curlres=$(curl --silent --header "Access-Token: $PB_API_KEY" \
+	curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
 	"$API_URL/devices")
 
 	# fail early on if token is invalid
@@ -165,7 +167,7 @@ getDevices() {
 	devices=$curlres
 	cursor=$(checkPagination "$curlres")
 	until [ -z $cursor ]; do
-		curlres=$(curl --silent --header "Access-Token: $PB_API_KEY" \
+		curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
 		--data-urlencode cursor=$cursor \
 		--get \
 		"$API_URL/devices")
@@ -204,7 +206,7 @@ getPushes() {
 		iden="/$iden"
 	fi
 
-	curlres=$(curl --silent --header "Access-Token: $PB_API_KEY" \
+	curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
 	--data-urlencode active="$active" \
 	--data-urlencode modified_after="$modified" \
 	--get \
@@ -214,7 +216,7 @@ getPushes() {
 
 	# check if query needs pagination
 	until [ -z "$(checkPagination "$curlres")" ]; do
-		curlres=$(curl --silent --header "Access-Token: $PB_API_KEY" \
+		curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
 		--data-urlencode active="$active" \
 		--data-urlencode modified_after="$modified" \
 		--data-urlencode cursor="$(checkPagination "$curlres")" \
@@ -245,7 +247,7 @@ create-device)
 		err "A device already exists with your hostname"
 		exit 1
 	fi
-	curlres=$(curl --silent --header "Access-Token: $PB_API_KEY" \
+	curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
 	--header 'Content-Type: application/json' \
 	--data-binary "{\"nickname\":\"$(hostname)\",\"model\":\"Created by pushbullet-bash\",\"icon\":\"system\"}" \
 	--request POST \
@@ -275,7 +277,7 @@ chat)
 			exit 1
 		fi
 		# as long as the object is an email the chat will either be created or already exists
-		curlres=$(curl --silent --header "Access-Token: $PB_API_KEY" \
+		curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
 		--header "Content-Type: application/json" \
 		--data-binary \{\"email\":\"$3\"\} \
 		--request POST \
@@ -328,7 +330,7 @@ delete)
 		;;
 	all)
 		info "deleting all pushes"
-		curlres=$(curl --silent --header "Access-Token: $PB_API_KEY" \
+		curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
 		--request DELETE \
 		"$API_URL/pushes")
 		checkCurlOutput "$curlres"
@@ -350,7 +352,7 @@ delete)
 		;;
 	*)
 		info "deleting $2"
-		curlres=$(curl --silent --header "Access-Token: $PB_API_KEY" \
+		curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
 		--request DELETE \
 		"$API_URL/pushes/$2")
 		checkCurlOutput "$curlres"
@@ -431,12 +433,12 @@ push)
 		fi
 		# Api docs: https://docs.pushbullet.com/v2/upload-request/
 		mimetype=$(file -i -b "$file")
-		curlres=$(curl --silent --header "Access-Token: $PB_API_KEY" \
+		curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
 		--header "Content-Type: application/json" \
 		--data-binary "{\"file_name\":\"$file\",\"file_type\":\"${mimetype%:*}\"}" \
 		--request POST \
 		"$API_URL/upload-request")
-		curlres2=$(curl --silent --include --request POST \
+		curlres2=$($CURL --silent --include --request POST \
 		$(echo "$curlres" | "$PROGDIR"/JSON.sh -b | grep upload_url | awk -F\" '{print $(NF-1)}') \
 		-F file=@"$file")
 
@@ -469,7 +471,7 @@ push)
 		info "Sending to device $dev_name"
 		json="$json,\"device_iden\":\"$dev_id\"}"
 	fi
-	curlres=$(curl --silent --header "Access-Token: $PB_API_KEY" \
+	curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
 	--header "Content-type: application/json" \
 	--data-binary "$json" \
 	--request POST \

--- a/pushbullet
+++ b/pushbullet
@@ -7,7 +7,7 @@ API_URL=https://api.pushbullet.com/v2
 PROGDIR="$(cd "$( dirname "$0" )" && pwd )"
 unset QUIET
 
-CURL="curl"
+CURLOPTS="--silent"
 
 info() {
 	if [[ -z ${QUIET} ]]; then
@@ -139,14 +139,14 @@ checkPagination() {
 }
 
 getChats() {
-	curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
+	curlres=$(curl $CURLOPTS --header "Access-Token: $PB_API_KEY" \
 	"$API_URL/chats")
 
 	# check if query needs pagination
 	chats=$curlres
 	cursor=$(checkPagination "$curlres")
 	until [ -z $cursor ]; do
-		curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
+		curlres=$(curl $CURLOPTS --header "Access-Token: $PB_API_KEY" \
 		--data-urlencode cursor=$cursor \
 		--get \
 		"$API_URL/chats")
@@ -157,7 +157,7 @@ getChats() {
 }
 
 getDevices() {
-	curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
+	curlres=$(curl $CURLOPTS --header "Access-Token: $PB_API_KEY" \
 	"$API_URL/devices")
 
 	# fail early on if token is invalid
@@ -167,7 +167,7 @@ getDevices() {
 	devices=$curlres
 	cursor=$(checkPagination "$curlres")
 	until [ -z $cursor ]; do
-		curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
+		curlres=$(curl $CURLOPTS --header "Access-Token: $PB_API_KEY" \
 		--data-urlencode cursor=$cursor \
 		--get \
 		"$API_URL/devices")
@@ -206,7 +206,7 @@ getPushes() {
 		iden="/$iden"
 	fi
 
-	curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
+	curlres=$(curl $CURLOPTS --header "Access-Token: $PB_API_KEY" \
 	--data-urlencode active="$active" \
 	--data-urlencode modified_after="$modified" \
 	--get \
@@ -216,7 +216,7 @@ getPushes() {
 
 	# check if query needs pagination
 	until [ -z "$(checkPagination "$curlres")" ]; do
-		curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
+		curlres=$(curl $CURLOPTS --header "Access-Token: $PB_API_KEY" \
 		--data-urlencode active="$active" \
 		--data-urlencode modified_after="$modified" \
 		--data-urlencode cursor="$(checkPagination "$curlres")" \
@@ -247,7 +247,7 @@ create-device)
 		err "A device already exists with your hostname"
 		exit 1
 	fi
-	curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
+	curlres=$(curl $CURLOPTS --header "Access-Token: $PB_API_KEY" \
 	--header 'Content-Type: application/json' \
 	--data-binary "{\"nickname\":\"$(hostname)\",\"model\":\"Created by pushbullet-bash\",\"icon\":\"system\"}" \
 	--request POST \
@@ -277,7 +277,7 @@ chat)
 			exit 1
 		fi
 		# as long as the object is an email the chat will either be created or already exists
-		curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
+		curlres=$(curl $CURLOPTS --header "Access-Token: $PB_API_KEY" \
 		--header "Content-Type: application/json" \
 		--data-binary \{\"email\":\"$3\"\} \
 		--request POST \
@@ -330,7 +330,7 @@ delete)
 		;;
 	all)
 		info "deleting all pushes"
-		curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
+		curlres=$(curl $CURLOPTS --header "Access-Token: $PB_API_KEY" \
 		--request DELETE \
 		"$API_URL/pushes")
 		checkCurlOutput "$curlres"
@@ -352,7 +352,7 @@ delete)
 		;;
 	*)
 		info "deleting $2"
-		curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
+		curlres=$(curl $CURLOPTS --header "Access-Token: $PB_API_KEY" \
 		--request DELETE \
 		"$API_URL/pushes/$2")
 		checkCurlOutput "$curlres"
@@ -433,12 +433,12 @@ push)
 		fi
 		# Api docs: https://docs.pushbullet.com/v2/upload-request/
 		mimetype=$(file -i -b "$file")
-		curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
+		curlres=$(curl $CURLOPTS --header "Access-Token: $PB_API_KEY" \
 		--header "Content-Type: application/json" \
 		--data-binary "{\"file_name\":\"$file\",\"file_type\":\"${mimetype%:*}\"}" \
 		--request POST \
 		"$API_URL/upload-request")
-		curlres2=$($CURL --silent --include --request POST \
+		curlres2=$(curl $CURLOPTS --include --request POST \
 		$(echo "$curlres" | "$PROGDIR"/JSON.sh -b | grep upload_url | awk -F\" '{print $(NF-1)}') \
 		-F file=@"$file")
 
@@ -471,7 +471,7 @@ push)
 		info "Sending to device $dev_name"
 		json="$json,\"device_iden\":\"$dev_id\"}"
 	fi
-	curlres=$($CURL --silent --header "Access-Token: $PB_API_KEY" \
+	curlres=$(curl $CURLOPTS --header "Access-Token: $PB_API_KEY" \
 	--header "Content-type: application/json" \
 	--data-binary "$json" \
 	--request POST \


### PR DESCRIPTION
In a DD-WRT environment, I don't always have the ability to set the CA certificates for connecting to secure websites. The right answer is to add certs so that `curl` will verify correctly. A hack can be to allow `--insecure`, at least for testing. By setting `CURL="curl --insecure"` at the top of this patch (or an addition for `--cacerts`), it works as anticipated.

This patch does not require the "POSIX" patch but I'm using them combined for the purposes of running on my DD-WRT router.